### PR TITLE
feat: add week selector for goal history

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,21 @@
+export function getCurrentWeekKey() {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = now.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
+  const monday = new Date(now.setDate(diff));
+  return monday.toISOString().split('T')[0]; // formats as YYYY-MM-DD
+}
+
+/**
+ * Generates a short, unique identifier with the following properties:
+ * - Starts with base36 timestamp (sortable)
+ * - Includes 3 random chars (collision prevention)
+ * - URL-safe (uses only alphanumeric chars)
+ * - Format: "timestamp-random" (e.g., "lrz5hj4-k7m")
+ * @returns {string} A unique identifier
+ */
+export function generateId() {
+  const timestamp = Date.now().toString(36); // base36 timestamp
+  const random = Math.random().toString(36).substring(2, 5); // 3 random chars
+  return `${timestamp}-${random}`;
+}

--- a/src/utils/dateUtils.test.js
+++ b/src/utils/dateUtils.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getCurrentWeekKey, generateId } from './dateUtils';
+
+describe('getCurrentWeekKey', () => {
+  beforeEach(() => {
+    // Reset the date to a known value before each test
+    vi.useFakeTimers();
+  });
+
+  it('returns Monday date when current day is Wednesday', () => {
+    // Use Date constructor with individual components to ensure
+    // local timezone and avoid shifts to adjacent days
+    // Note: months are 0-based (0-11)
+    const testDate = new Date(2024, 2, 20, 12, 0, 0);
+    expect(testDate.getDay()).toBe(3);
+    vi.setSystemTime(testDate);
+    expect(getCurrentWeekKey()).toBe('2024-03-18');
+  });
+
+  it('returns previous Monday date when current day is Sunday', () => {
+    // Use Date constructor with individual components to ensure
+    // local timezone and avoid shifts to adjacent days
+    // Note: months are 0-based (0-11)
+    const testDate = new Date(2024, 2, 24, 12, 0, 0);
+    expect(testDate.getDay()).toBe(0);
+    vi.setSystemTime(testDate);
+    expect(getCurrentWeekKey()).toBe('2024-03-18');
+  });
+
+  it('returns current date when current day is Monday', () => {
+    // Use Date constructor with individual components to ensure
+    // local timezone and avoid shifts to adjacent days
+    // Note: months are 0-based (0-11)
+    const testDate = new Date(2024, 2, 25, 12, 0, 0);
+    expect(testDate.getDay()).toBe(1);
+    vi.setSystemTime(testDate);
+    expect(getCurrentWeekKey()).toBe('2024-03-25');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+});
+
+describe('generateId', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789);
+  });
+
+  it('generates an ID with the expected format', () => {
+    // Use Date constructor with individual components to ensure
+    // local timezone and avoid shifts to adjacent days
+    const testDate = new Date(2024, 2, 25, 12, 0, 0);
+    vi.setSystemTime(testDate);
+    const id = generateId();
+
+    // Check format
+    expect(id).toMatch(/^[a-z0-9]+-[a-z0-9]{3}$/);
+
+    // Check specific parts
+    const [timestamp, random] = id.split('-');
+    expect(random).toBe(Math.random().toString(36).substring(2, 5));
+    expect(timestamp).toBe(testDate.getTime().toString(36));
+  });
+
+  it('generates unique IDs', () => {
+    const ids = new Set();
+    for (let i = 0; i < 10; i++) {
+      vi.setSystemTime(new Date(2024, 2, 25, 12, 0, i)); // Increment time for each iteration
+      ids.add(generateId());
+    }
+    expect(ids.size).toBe(10); // All IDs should be unique
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
- Implement week selection dropdown in MainPage header
- Add date utilities for Monday-based week calculations
- Create comprehensive tests for week selection and date handling
- Allow viewing and managing goals across different weeks

Users can now switch between different weeks to view and manage their historical goals while maintaining separate goal counts for each week. The implementation uses Monday-based weeks with proper date formatting and includes thorough test coverage.