### PR TITLE
fix: ensure getCurrentWeekKey returns correct Monday in local timezone

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -3,7 +3,13 @@ export function getCurrentWeekKey() {
   const day = now.getDay();
   const diff = now.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
   const monday = new Date(now.setDate(diff));
-  return monday.toISOString().split('T')[0]; // formats as YYYY-MM-DD
+  return (
+    monday.getFullYear() +
+    '-' +
+    String(monday.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(monday.getDate()).padStart(2, '0')
+  );
 }
 
 /**

--- a/src/utils/dateUtils.test.js
+++ b/src/utils/dateUtils.test.js
@@ -37,6 +37,26 @@ describe('getCurrentWeekKey', () => {
     expect(getCurrentWeekKey()).toBe('2024-03-25');
   });
 
+  it('returns consistent Monday when called near midnight', () => {
+    // Wednesday 11:50 PM
+    // Note: months are 0-based (0-11)
+    const lateNightDate = new Date(2024, 2, 20, 23, 50, 0);
+    expect(lateNightDate.getDay()).toBe(3);
+    vi.setSystemTime(lateNightDate);
+    const lateNightResult = getCurrentWeekKey();
+
+    // Thursday 12:10 AM (next day)
+    // Note: months are 0-based (0-11)
+    const earlyMorningDate = new Date(2024, 2, 21, 0, 10, 0);
+    expect(earlyMorningDate.getDay()).toBe(4);
+    vi.setSystemTime(earlyMorningDate);
+    const earlyMorningResult = getCurrentWeekKey();
+
+    // Both should return the same Monday
+    expect(lateNightResult).toBe('2024-03-18');
+    expect(earlyMorningResult).toBe('2024-03-18');
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });


### PR DESCRIPTION
Previously, getCurrentWeekKey calculated the correct local Monday date but then converted it to UTC using toISOString(). This caused issues when the function was called near midnight - for example, if called on Wednesday to find Monday's date, and that Monday was at 11:50 PM local time, the UTC conversion would shift it to Tuesday, returning the wrong date.

- Replace toISOString() with local date components
- Use getFullYear(), getMonth(), and getDate() to maintain local time
- Add test cases for midnight edge cases (11:50 PM and 12:10 AM)
- Maintain YYYY-MM-DD format