### PR TITLE
fix: exit edit mode after deleting a goal

### DIFF
--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -158,6 +158,7 @@ const MainPage = ({
         [selectedWeek]: goals,
       }));
       setEditingGoal(null);
+      setIsEditing(false);
     } catch (error) {
       console.error('Failed to delete goal:', error);
     } finally {

--- a/src/pages/MainPage.test.jsx
+++ b/src/pages/MainPage.test.jsx
@@ -107,7 +107,7 @@ describe('MainPage', () => {
     expect(screen.getByText('Updated Goal')).toBeInTheDocument();
   });
 
-  it('deletes a goal', async () => {
+  it('deletes a goal and exits edit mode', async () => {
     const service = new InMemoryGoalsService();
     await service.addGoal('2024-03-25', testGoal);
 
@@ -120,7 +120,13 @@ describe('MainPage', () => {
     // Delete the goal
     await userEvent.click(screen.getByText('Delete'));
 
-    expect(screen.queryByText('Test Goal')).not.toBeInTheDocument();
+    await waitFor(() => {
+      // Check that the goal is deleted
+      expect(screen.queryByText('Test Goal')).not.toBeInTheDocument();
+      // Check that we're back in non-edit mode (Edit button is visible)
+      expect(screen.getByText('Edit')).toBeInTheDocument();
+      expect(screen.queryByText('Done')).not.toBeInTheDocument();
+    });
   });
 
   describe('week selector', () => {


### PR DESCRIPTION
When deleting a goal, the app now properly exits edit mode. Previously, the edit mode would remain active after deletion, leading to a confusing user experience.

- Added setIsEditing(false) to handleDeleteGoal function
- Updated test to verify edit mode is exited after deletion