### PR TITLE
feat: Add tally marks display for goal counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.1"
       },
       "devDependencies": {
@@ -5971,6 +5972,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.3.1",
@@ -46,7 +48,6 @@
     "jsdom": "^24.1.3",
     "prettier": "^3.4.2",
     "vite": "^6.0.5",
-    "vitest": "^1.6.0",
-    "@firebase/rules-unit-testing": "^4.0.1"
+    "vitest": "^1.6.0"
   }
 }

--- a/src/components/TallyMarks.jsx
+++ b/src/components/TallyMarks.jsx
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import {
+  TbTallymark1,
+  TbTallymark2,
+  TbTallymark3,
+  TbTallymark4,
+  TbTallymarks,
+} from 'react-icons/tb';
+
+const TallyMarks = ({ count }) => {
+  // If count is greater than 15, just show the number
+  if (count == 0 || count > 15) {
+    return <Typography variant="h4">{count}</Typography>;
+  }
+
+  const getTallyGroups = () => {
+    const groups = [];
+    const fullGroups = Math.floor(count / 5);
+    const remainder = count % 5;
+
+    // Add full groups (5 marks)
+    for (let i = 0; i < fullGroups; i++) {
+      groups.push(
+        <TbTallymarks
+          key={`group-${i}`}
+          data-testid="tally-mark"
+          style={{ fontSize: '2.5rem', height: '42px', width: '42px' }}
+        />
+      );
+    }
+
+    // Add remaining marks based on count
+    if (remainder > 0) {
+      const RemainderIcon = {
+        1: TbTallymark1,
+        2: TbTallymark2,
+        3: TbTallymark3,
+        4: TbTallymark4,
+      }[remainder];
+
+      groups.push(
+        <RemainderIcon
+          key="remainder"
+          data-testid="tally-mark"
+          style={{ fontSize: '2.5rem', height: '42px', width: '42px' }}
+        />
+      );
+    }
+
+    return groups;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        alignItems: 'center',
+        height: '42px',
+        width: '42px',
+      }}
+    >
+      <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+        {getTallyGroups()}
+      </Box>
+    </Box>
+  );
+};
+
+TallyMarks.propTypes = {
+  count: PropTypes.number.isRequired,
+};
+
+export default TallyMarks;

--- a/src/components/TallyMarks.test.jsx
+++ b/src/components/TallyMarks.test.jsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TallyMarks from './TallyMarks';
+
+describe('TallyMarks', () => {
+  it('renders tally marks for numbers up to 15', () => {
+    render(<TallyMarks count={5} />);
+    // Find the SVG element directly
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    // Verify it's the 5-mark tally by checking for 5 paths
+    const paths = svg.querySelectorAll('path');
+    expect(paths).toHaveLength(5);
+  });
+
+  it('switches to numerical display for numbers above 15', () => {
+    render(<TallyMarks count={16} />);
+    expect(screen.getByText('16')).toBeInTheDocument();
+  });
+
+  it('renders correct number of tally groups', () => {
+    render(<TallyMarks count={7} />);
+    // Should show one group of 5 and one group of 2
+    const svgs = document.querySelectorAll('svg');
+    expect(svgs).toHaveLength(2);
+  });
+
+  it('renders single tally for count of 1', () => {
+    render(<TallyMarks count={1} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    // Verify it's a single tally by checking path count
+    const paths = svg.querySelectorAll('path');
+    expect(paths).toHaveLength(1);
+  });
+});

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -17,6 +17,7 @@ import { getCurrentWeekKey } from '../utils/dateUtils';
 import PropTypes from 'prop-types';
 import FirestoreGoalsService from '../services/goals/FirestoreGoalsService';
 import CircularProgress from '@mui/material/CircularProgress';
+import TallyMarks from '../components/TallyMarks';
 
 // Create default instance
 const defaultService = new FirestoreGoalsService();
@@ -244,7 +245,7 @@ const MainPage = ({
                     alignItems: 'center',
                   }}
                 >
-                  <Typography variant="h4">{goal.count}</Typography>
+                  <TallyMarks count={goal.count} />
                   {!isEditing && (
                     <Button
                       variant="contained"

--- a/src/pages/MainPage.test.jsx
+++ b/src/pages/MainPage.test.jsx
@@ -13,6 +13,13 @@ vi.mock('../utils/dateUtils', async () => {
   };
 });
 
+// Helper function to get path count from tally marks
+const getTallyPathCount = () => {
+  const svgs = screen.getAllByTestId('tally-mark');
+  expect(svgs[0]).toBeInTheDocument();
+  return svgs[0].querySelectorAll('path').length;
+};
+
 describe('MainPage', () => {
   const testGoal = {
     id: 'test-id',
@@ -71,9 +78,7 @@ describe('MainPage', () => {
     const plusButton = screen.getByTestId('PlusOneIcon').parentElement;
     await userEvent.click(plusButton);
 
-    await waitFor(() => {
-      expect(screen.getByText('1')).toBeInTheDocument();
-    });
+    await waitFor(() => expect(getTallyPathCount()).toBe(1));
   });
 
   it('enables editing mode when clicking Edit button', async () => {
@@ -214,7 +219,7 @@ describe('MainPage', () => {
       render(<MainPage goalsService={service} />);
 
       // Check current week count
-      await waitFor(() => expect(screen.getByText('1')).toBeInTheDocument());
+      await waitFor(() => expect(getTallyPathCount()).toBe(1));
 
       // Click the select to open it
       await userEvent.click(screen.getByRole('combobox'));
@@ -222,7 +227,7 @@ describe('MainPage', () => {
       await userEvent.click(screen.getByText('Mar 18, 2024'));
 
       // Check previous week has different count
-      await waitFor(() => expect(screen.getByText('2')).toBeInTheDocument());
+      await waitFor(() => expect(getTallyPathCount()).toBe(2));
     });
   });
 


### PR DESCRIPTION
- Create TallyMarks component to display counts as tally marks up to 15
- Use react-icons/tb for tally mark icons
- Match tally mark height with MUI Typography h4
- Add comprehensive tests for tally mark rendering
- Replace numerical count display in MainPage with TallyMarks component

The component switches to numerical display for counts above 15 to save space.