### PR TITLE
feat: add statistics page with goal insights

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,7 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.jest,
+        ...globals.node,
       },
     },
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.4.0",
-        "react-router-dom": "^7.1.1"
+        "react-router-dom": "^7.1.1",
+        "recharts": "^2.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -2472,6 +2473,60 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -3349,6 +3404,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -3434,6 +3599,11 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -4096,6 +4266,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4107,6 +4282,14 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4692,6 +4875,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -5283,8 +5474,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -6034,6 +6224,20 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -6048,6 +6252,41 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
+      "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -6706,6 +6945,11 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6968,6 +7212,27 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
-    "react-router-dom": "^7.1.1"
+    "react-router-dom": "^7.1.1",
+    "recharts": "^2.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { ThemeProvider, Container } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import MainPage from './pages/MainPage';
+import StatsPage from './pages/StatsPage';
 import Login from './pages/Login';
 import { auth } from './firebase';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -28,6 +29,14 @@ function App() {
         <NavBar user={user} />
         <Container maxWidth="sm">
           <Routes>
+            <Route
+              path="/stats"
+              element={
+                <ProtectedRoute user={user}>
+                  <StatsPage />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path="/"
               element={

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -19,6 +19,16 @@ function NavBar({ user = null }) {
         <Button color="inherit" component={RouterLink} to="/" sx={{ mr: 2 }}>
           Home
         </Button>
+        {user && (
+          <Button
+            color="inherit"
+            component={RouterLink}
+            to="/stats"
+            sx={{ mr: 2 }}
+          >
+            Stats
+          </Button>
+        )}
         <Box sx={{ flexGrow: 1 }} />
         {user ? (
           <Button color="inherit" onClick={handleLogout}>

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -1,0 +1,278 @@
+import { useState, useEffect } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import {
+  Container,
+  Typography,
+  Grid2 as Grid,
+  Card,
+  CardHeader,
+  CardContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  FormControl,
+  Select,
+  MenuItem,
+  CircularProgress,
+  Box,
+} from '@mui/material';
+import PropTypes from 'prop-types';
+import GoalsAnalyticsService from '../services/analytics/GoalsAnalyticsService';
+import FirestoreGoalsService from '../services/goals/FirestoreGoalsService';
+
+// Create default instances
+const analyticsService = new GoalsAnalyticsService();
+const defaultService = new FirestoreGoalsService();
+
+const StatsPage = ({ goalsService = defaultService }) => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedGoals, setSelectedGoals] = useState([]);
+  const MAX_VISIBLE_GOALS = 3;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        const historicalData = await goalsService.getAllHistoricalGoals();
+        const processedData = analyticsService.processGoalStats(historicalData);
+        setData(processedData);
+
+        // Initialize with top goals
+        const topGoals = [...processedData.goalStats]
+          .sort((a, b) => b.totalCount - a.totalCount)
+          .slice(0, MAX_VISIBLE_GOALS)
+          .map(goal => goal.name);
+        setSelectedGoals(topGoals);
+      } catch (err) {
+        console.error('Failed to load stats:', err);
+        setError(err.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [goalsService]);
+
+  const handleGoalSelect = event => {
+    setSelectedGoals(event.target.value);
+  };
+
+  if (isLoading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="60vh"
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography color="error" variant="h6">
+          Error loading stats: {error}
+        </Typography>
+      </Container>
+    );
+  }
+
+  if (!data || data.goalStats.length === 0) {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography variant="h6">No data available</Typography>
+      </Container>
+    );
+  }
+
+  const formatDate = weekId => {
+    return new Date(weekId + 'T00:00:00').toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
+        Goal Insights
+      </Typography>
+
+      {/* Summary Cards */}
+      <Grid container spacing={2} columns={{ xs: 1, sm: 2 }} sx={{ mb: 4 }}>
+        <Grid size={1}>
+          <Card sx={{ height: '100%' }}>
+            <CardHeader
+              title="Most Consistent Goal"
+              titleTypographyProps={{ variant: 'h6' }}
+            />
+            <CardContent>
+              <Typography variant="h5">
+                {data.summary.mostConsistentGoal.name}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {data.summary.mostConsistentGoal.consistency} weekly completion
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={1}>
+          <Card sx={{ height: '100%' }}>
+            <CardHeader
+              title="All-Time Records"
+              titleTypographyProps={{ variant: 'h6' }}
+            />
+            <CardContent>
+              <Typography variant="h5">
+                {data.summary.totalActions} Total Actions
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Across all goals
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={1}>
+          <Card sx={{ height: '100%' }}>
+            <CardHeader
+              title="Current Week Progress"
+              titleTypographyProps={{ variant: 'h6' }}
+            />
+            <CardContent>
+              <Typography variant="h5">15 Actions</Typography>
+              <Typography variant="body2" color="text.secondary">
+                20% above average
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* Trends Chart */}
+      <Card sx={{ mb: 4 }}>
+        <CardHeader
+          title="Progress Over Time"
+          titleTypographyProps={{ variant: 'h6' }}
+          action={
+            <FormControl sx={{ m: 1, minWidth: 200 }}>
+              <Select
+                multiple
+                value={selectedGoals}
+                onChange={handleGoalSelect}
+                renderValue={selected => selected.join(', ')}
+              >
+                {data.goalStats.map(goal => (
+                  <MenuItem
+                    key={goal.name}
+                    value={goal.name}
+                    disabled={
+                      selectedGoals.length >= MAX_VISIBLE_GOALS &&
+                      !selectedGoals.includes(goal.name)
+                    }
+                  >
+                    {goal.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          }
+        />
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data.weeklyTrends}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="week" tickFormatter={formatDate} />
+              <YAxis />
+              <Tooltip labelFormatter={formatDate} />
+              <Legend />
+              {data.goalStats
+                .filter(goal => selectedGoals.includes(goal.name))
+                .map((goal, index) => (
+                  <Line
+                    key={goal.name}
+                    type="monotone"
+                    dataKey={goal.name}
+                    stroke={['#fbd734', '#6383fa', '#8efc63'][index]}
+                    strokeWidth={2}
+                    connectNulls={false}
+                    dot={{ r: 4 }}
+                    activeDot={{ r: 6 }}
+                  />
+                ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* Goal Statistics Table - make it scrollable on mobile */}
+      <Card>
+        <CardHeader
+          title="Goal Statistics"
+          titleTypographyProps={{ variant: 'h6' }}
+        />
+        <CardContent sx={{ p: { xs: 0, sm: 2 } }}>
+          <TableContainer
+            component={Paper}
+            sx={{
+              maxWidth: '100%',
+              overflowX: 'auto',
+            }}
+          >
+            <Table aria-label="goal statistics">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Goal</TableCell>
+                  <TableCell align="right">Total Count</TableCell>
+                  <TableCell align="right">Weekly Average</TableCell>
+                  <TableCell align="right">Best Week</TableCell>
+                  <TableCell align="right">Consistency</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.goalStats.map(goal => (
+                  <TableRow key={goal.name}>
+                    <TableCell component="th" scope="row">
+                      {goal.name}
+                    </TableCell>
+                    <TableCell align="right">{goal.totalCount}</TableCell>
+                    <TableCell align="right">{goal.weeklyAverage}</TableCell>
+                    <TableCell align="right">{goal.bestWeek}</TableCell>
+                    <TableCell align="right">{goal.consistency}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+};
+
+StatsPage.propTypes = {
+  goalsService: PropTypes.shape({
+    getAllHistoricalGoals: PropTypes.func.isRequired,
+  }),
+};
+
+export default StatsPage;

--- a/src/pages/StatsPage.test.jsx
+++ b/src/pages/StatsPage.test.jsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StatsPage from './StatsPage';
+import InMemoryGoalsService from '../services/goals/InMemoryGoalsService';
+
+// Mock ResizeObserver
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('StatsPage', () => {
+  const mockHistoricalData = [
+    {
+      id: '2024-03-25',
+      goals: [
+        { id: 'goal1', title: 'Exercise', count: 5 },
+        { id: 'goal2', title: 'Read', count: 3 },
+      ],
+    },
+    {
+      id: '2024-03-18',
+      goals: [
+        { id: 'goal1', title: 'Exercise', count: 4 },
+        { id: 'goal2', title: 'Read', count: 2 },
+      ],
+    },
+  ];
+
+  it('renders loading state initially', async () => {
+    const service = new InMemoryGoalsService({}, 100);
+
+    service._getBarrier('getAllHistoricalGoals');
+
+    render(<StatsPage goalsService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByText('Goal Insights')).not.toBeInTheDocument();
+      expect(screen.queryByText('No data available')).not.toBeInTheDocument();
+    });
+
+    service.resolveOperation('getAllHistoricalGoals');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      expect(screen.queryByText('Goal Insights')).not.toBeInTheDocument();
+      expect(screen.queryByText('No data available')).toBeInTheDocument();
+    });
+  });
+
+  it('displays goal insights when data loads', async () => {
+    const service = new InMemoryGoalsService(mockHistoricalData);
+    render(<StatsPage goalsService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Goal Insights')).toBeInTheDocument();
+
+      // Find the statistics table
+      const statsTable = screen.getByRole('table', {
+        name: 'goal statistics',
+      });
+      expect(statsTable).toBeInTheDocument();
+
+      // Find the Exercise row
+      const exerciseRow = within(statsTable).getByRole('row', {
+        name: /Exercise 9 4\.5 5 100%/,
+      });
+      expect(exerciseRow).toBeInTheDocument();
+
+      // Find the Read row
+      const readRow = within(statsTable).getByRole('row', {
+        name: /Read 5 2\.5 3 100%/,
+      });
+      expect(readRow).toBeInTheDocument();
+    });
+  });
+
+  it('allows switching between goals in the chart', async () => {
+    const service = new InMemoryGoalsService(mockHistoricalData);
+    render(<StatsPage goalsService={service} />);
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Goal Insights')).toBeInTheDocument();
+    });
+
+    // Open the select
+    const select = screen.getByRole('combobox');
+    await userEvent.click(select);
+
+    // Initially both should be selected
+    expect(select).toHaveTextContent('Exercise, Read');
+
+    // Deselect Exercise
+    const exerciseOption = screen.getByRole('option', { name: 'Exercise' });
+    await userEvent.click(exerciseOption);
+
+    // Now only Read should be selected
+    await waitFor(() => {
+      expect(select).toHaveTextContent('Read');
+    });
+
+    // Select Exercise again
+    await userEvent.click(exerciseOption);
+
+    // Now both should be selected again
+    await waitFor(() => {
+      expect(select).toHaveTextContent('Read, Exercise');
+    });
+  });
+
+  it('handles service errors gracefully', async () => {
+    const service = new InMemoryGoalsService();
+    const error = new Error('Failed to load historical data');
+    vi.spyOn(service, 'getAllHistoricalGoals').mockRejectedValue(error);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<StatsPage goalsService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading stats/)).toBeInTheDocument();
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load stats:', error);
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('shows no data message when there are no goals', async () => {
+    const service = new InMemoryGoalsService({});
+    render(<StatsPage goalsService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No data available')).toBeInTheDocument();
+    });
+  });
+
+  it('displays summary cards with stats', async () => {
+    const service = new InMemoryGoalsService(mockHistoricalData);
+    render(<StatsPage goalsService={service} />);
+
+    await waitFor(() => {
+      // Check card titles
+      expect(screen.getByText('Most Consistent Goal')).toBeInTheDocument();
+      expect(screen.getByText('All-Time Records')).toBeInTheDocument();
+      expect(screen.getByText('Current Week Progress')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/services/analytics/GoalsAnalyticsService.js
+++ b/src/services/analytics/GoalsAnalyticsService.js
@@ -1,0 +1,107 @@
+/**
+ * Service for calculating analytics and statistics from raw goals data
+ */
+class GoalsAnalyticsService {
+  /**
+   * @param {Array<{id: string, goals: Goal[]}>} weeklyGoals - Array of week documents with their goals
+   * @returns {Object} Processed statistics for all goals
+   */
+  processGoalStats(weeklyGoals) {
+    // First, get all unique goal titles
+    const goalTitles = new Set();
+    weeklyGoals.forEach(week => {
+      week.goals.forEach(goal => goalTitles.add(goal.title));
+    });
+
+    // Calculate stats for each goal
+    const goalStats = Array.from(goalTitles).map(title => ({
+      name: title,
+      ...this.calculateGoalStats(title, weeklyGoals),
+    }));
+
+    return {
+      goalStats,
+      weeklyTrends: this.calculateWeeklyTrends(weeklyGoals),
+      summary: this.calculateSummaryStats(goalStats),
+    };
+  }
+
+  /**
+   * @private
+   */
+  calculateGoalStats(goalTitle, weeklyGoals) {
+    let totalCount = 0;
+    let bestWeek = 0;
+    let activeWeeks = 0;
+    const totalWeeks = weeklyGoals.length;
+
+    weeklyGoals.forEach(week => {
+      const goal = week.goals.find(g => g.title === goalTitle);
+      if (goal) {
+        totalCount += goal.count;
+        bestWeek = Math.max(bestWeek, goal.count);
+        if (goal.count > 0) activeWeeks++;
+      }
+    });
+
+    return {
+      totalCount,
+      // TODO: maybe add "active weekly average" which only considers active weeks.
+      // Could be useful, so we don't see the average drop over time after the user
+      // is no longer working on this goal. Could also consider the range of weeks
+      // (first week the user worked on this goal and last week he worked on it).
+      weeklyAverage: totalWeeks > 0 ? (totalCount / totalWeeks).toFixed(1) : 0,
+      bestWeek,
+      consistency:
+        totalWeeks > 0
+          ? `${((activeWeeks / totalWeeks) * 100).toFixed(0)}%`
+          : '0%',
+    };
+  }
+
+  /**
+   * @private
+   */
+  calculateWeeklyTrends(weeklyGoals) {
+    return weeklyGoals.map(week => {
+      const dataPoint = { week: week.id };
+      week.goals.forEach(goal => {
+        dataPoint[goal.title] = goal.count;
+      });
+      return dataPoint;
+    });
+  }
+
+  /**
+   * @private
+   */
+  calculateSummaryStats(goalStats) {
+    if (goalStats.length === 0) {
+      return {
+        mostConsistentGoal: {
+          name: '',
+          consistency: '0%',
+        },
+        totalActions: 0,
+      };
+    }
+
+    const mostConsistentGoal = goalStats.reduce((prev, current) => {
+      const prevPercentage = parseInt(prev.consistency);
+      const currentPercentage = parseInt(current.consistency);
+      return currentPercentage > prevPercentage ? current : prev;
+    });
+
+    const totalActions = goalStats.reduce(
+      (sum, goal) => sum + goal.totalCount,
+      0
+    );
+
+    return {
+      mostConsistentGoal,
+      totalActions,
+    };
+  }
+}
+
+export default GoalsAnalyticsService;

--- a/src/services/analytics/GoalsAnalyticsService.test.js
+++ b/src/services/analytics/GoalsAnalyticsService.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import GoalsAnalyticsService from './GoalsAnalyticsService';
+
+const mockHistoricalData = [
+  {
+    id: '2024-01-01',
+    goals: [
+      { id: '1', title: 'Exercise', count: 3 },
+      { id: '2', title: 'Reading', count: 5 },
+    ],
+  },
+  {
+    id: '2024-01-08',
+    goals: [
+      { id: '3', title: 'Exercise', count: 4 },
+      { id: '4', title: 'Reading', count: 0 },
+    ],
+  },
+];
+
+describe('GoalsAnalyticsService', () => {
+  it('processes goal stats correctly', () => {
+    const service = new GoalsAnalyticsService();
+    const stats = service.processGoalStats(mockHistoricalData);
+
+    expect(stats).toEqual({
+      goalStats: [
+        {
+          name: 'Exercise',
+          totalCount: 7,
+          weeklyAverage: '3.5',
+          bestWeek: 4,
+          consistency: '100%',
+        },
+        {
+          name: 'Reading',
+          totalCount: 5,
+          weeklyAverage: '2.5',
+          bestWeek: 5,
+          consistency: '50%',
+        },
+      ],
+      weeklyTrends: [
+        {
+          week: '2024-01-01',
+          Exercise: 3,
+          Reading: 5,
+        },
+        {
+          week: '2024-01-08',
+          Exercise: 4,
+          Reading: 0,
+        },
+      ],
+      summary: {
+        mostConsistentGoal: {
+          name: 'Exercise',
+          totalCount: 7,
+          weeklyAverage: '3.5',
+          bestWeek: 4,
+          consistency: '100%',
+        },
+        totalActions: 12,
+      },
+    });
+  });
+
+  it('handles empty data', () => {
+    const service = new GoalsAnalyticsService();
+    const stats = service.processGoalStats([]);
+
+    expect(stats).toEqual({
+      goalStats: [],
+      weeklyTrends: [],
+      summary: {
+        mostConsistentGoal: {
+          name: '',
+          consistency: '0%',
+        },
+        totalActions: 0,
+      },
+    });
+  });
+
+  it('handles weeks with no goals', () => {
+    const service = new GoalsAnalyticsService();
+    const stats = service.processGoalStats([
+      {
+        id: '2024-01-01',
+        goals: [],
+      },
+    ]);
+
+    expect(stats).toEqual({
+      goalStats: [],
+      weeklyTrends: [
+        {
+          week: '2024-01-01',
+        },
+      ],
+      summary: {
+        mostConsistentGoal: {
+          name: '',
+          consistency: '0%',
+        },
+        totalActions: 0,
+      },
+    });
+  });
+
+  it('calculates consistency correctly with partial weeks', () => {
+    const service = new GoalsAnalyticsService();
+    const stats = service.processGoalStats([
+      {
+        id: '2024-01-01',
+        goals: [{ id: '1', title: 'Exercise', count: 3 }],
+      },
+      {
+        id: '2024-01-08',
+        goals: [{ id: '2', title: 'Exercise', count: 0 }],
+      },
+    ]);
+
+    expect(stats.goalStats[0].consistency).toBe('50%');
+  });
+
+  it('handles goals that are not present in every week', () => {
+    const service = new GoalsAnalyticsService();
+    const stats = service.processGoalStats([
+      {
+        id: '2024-01-01',
+        goals: [
+          { id: '1', title: 'Exercise', count: 3 },
+          { id: '2', title: 'Reading', count: 5 },
+        ],
+      },
+      {
+        id: '2024-01-08',
+        goals: [
+          { id: '3', title: 'Exercise', count: 4 },
+          { id: '4', title: 'Meditation', count: 2 },
+        ],
+      },
+      {
+        id: '2024-01-15',
+        goals: [
+          { id: '5', title: 'Meditation', count: 3 },
+          { id: '6', title: 'Exercise', count: 2 },
+        ],
+      },
+    ]);
+
+    expect(stats.goalStats).toEqual([
+      {
+        name: 'Exercise',
+        totalCount: 9,
+        weeklyAverage: '3.0',
+        bestWeek: 4,
+        consistency: '100%',
+      },
+      {
+        name: 'Reading',
+        totalCount: 5,
+        weeklyAverage: '1.7',
+        bestWeek: 5,
+        consistency: '33%',
+      },
+      {
+        name: 'Meditation',
+        totalCount: 5,
+        weeklyAverage: '1.7',
+        bestWeek: 3,
+        consistency: '67%',
+      },
+    ]);
+
+    expect(stats.weeklyTrends).toEqual([
+      {
+        week: '2024-01-01',
+        Exercise: 3,
+        Reading: 5,
+        Meditation: undefined,
+      },
+      {
+        week: '2024-01-08',
+        Exercise: 4,
+        Reading: undefined,
+        Meditation: 2,
+      },
+      {
+        week: '2024-01-15',
+        Exercise: 2,
+        Reading: undefined,
+        Meditation: 3,
+      },
+    ]);
+  });
+});

--- a/src/services/goals/FirestoreGoalsService.js
+++ b/src/services/goals/FirestoreGoalsService.js
@@ -132,6 +132,23 @@ class FirestoreGoalsService extends GoalsService {
       .sort()
       .reverse();
   }
+
+  /**
+   * @returns {Promise<Array<{id: string, goals: Goal[]}>>}
+   */
+  async getAllHistoricalGoals() {
+    if (!auth.currentUser?.uid) throw new Error('User not authenticated');
+
+    const weeksRef = collection(db, 'users', auth.currentUser.uid, 'weeks');
+    const snapshot = await getDocs(weeksRef);
+
+    return snapshot.docs
+      .map(doc => ({
+        id: doc.id,
+        goals: doc.data().goals || [],
+      }))
+      .sort();
+  }
 }
 
 export default FirestoreGoalsService;

--- a/src/services/goals/GoalsService.js
+++ b/src/services/goals/GoalsService.js
@@ -71,6 +71,15 @@ class GoalsService {
   async getAvailableWeeks() {
     throw new Error('Not implemented');
   }
+
+  /**
+   * Gets all historical goals across all weeks
+   * @returns {Promise<Array<{id: string, goals: Goal[]}>>} Array of week documents with their goals
+   * @throws {Error} If user is not authenticated
+   */
+  async getAllHistoricalGoals() {
+    throw new Error('Not implemented');
+  }
 }
 
 export default GoalsService;

--- a/src/services/goals/InMemoryGoalsService.js
+++ b/src/services/goals/InMemoryGoalsService.js
@@ -100,6 +100,17 @@ class InMemoryGoalsService extends GoalsService {
     await this._delay('getAvailableWeeks');
     return Object.keys(this.weeks).sort().reverse();
   }
+
+  async getAllHistoricalGoals() {
+    await this._delay('getAllHistoricalGoals');
+    return Object.entries(this.weeks)
+      .map(([id, week]) => ({
+        id,
+        goals: [...week.goals], // Create a copy of the goals array
+      }))
+      .sort((a, b) => b.id.localeCompare(a.id))
+      .reverse();
+  }
 }
 
 export default InMemoryGoalsService;


### PR DESCRIPTION
Add a new statistics page that provides insights and analytics for user goals, including:
- Weekly trends chart with multi-goal selection
- Goal statistics table with totals and averages
- Summary cards showing key metrics
- Responsive layout for mobile and desktop

Technical changes:
- Add StatsPage component with tests
- Implement getAllHistoricalGoals in GoalsService interface
- Add FirestoreGoalsService implementation for historical data
- Create GoalsAnalyticsService for data processing
- Update App and NavBar to include new route
- Add InMemoryGoalsService test helpers

The page processes historical goal data to show:
- Progress over time with interactive charts
- Goal completion consistency
- Weekly averages and best weeks
- Total actions across all goals