### PR TITLE
fix: use most recent week for current week stats

### DIFF
--- a/src/services/analytics/GoalsAnalyticsService.js
+++ b/src/services/analytics/GoalsAnalyticsService.js
@@ -112,7 +112,7 @@ class GoalsAnalyticsService {
 
     // Calculate current week's total actions from the goals
     const currentWeekActions = Object.values(
-      weeklyTrends[0]?.goals || {}
+      weeklyTrends[weeklyTrends.length - 1]?.goals || {}
     ).reduce((sum, count) => sum + (count || 0), 0);
 
     const averageActions = totalActions / weeklyTrends.length;

--- a/src/services/analytics/GoalsAnalyticsService.test.js
+++ b/src/services/analytics/GoalsAnalyticsService.test.js
@@ -66,8 +66,8 @@ describe('GoalsAnalyticsService', () => {
         },
         totalActions: 12,
         currentWeekStats: {
-          totalActions: 8,
-          percentFromAverage: 33,
+          totalActions: 4,
+          percentFromAverage: -33,
         },
       },
     });


### PR DESCRIPTION
The current week stats were using the first week in the array instead of the most recent week. Updated calculateSummaryStats to use the last week's data (weeklyTrends.length - 1) for a more accurate comparison with the historical average.