### PR TITLE
fix: chart on the StatsPage

### DIFF
--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -205,7 +205,12 @@ const StatsPage = ({ goalsService = defaultService }) => {
         />
         <CardContent>
           <ResponsiveContainer width="100%" height={300}>
-            <LineChart data={data.weeklyTrends}>
+            <LineChart
+              data={data.weeklyTrends.map(week => ({
+                week: week.week,
+                ...week.goals,
+              }))}
+            >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="week" tickFormatter={formatDate} />
               <YAxis />


### PR DESCRIPTION
- Format the weeklyTrends data, so that it works with recharts.

We previously refactored the weeklyTrends objects, but forgot to update their usage in the chart.