### PR TITLE
fix: remove extra space from +1 button

### DIFF
--- a/src/pages/MainPage/components/GoalCard/GoalCard.jsx
+++ b/src/pages/MainPage/components/GoalCard/GoalCard.jsx
@@ -60,8 +60,6 @@ const GoalCard = ({
         {!isEditing && (
           <Box
             sx={{
-              width: '5rem',
-              minWidth: '5rem',
               ml: 2,
               display: 'flex',
               alignItems: 'center',


### PR DESCRIPTION
This would make the button jump further to the right when the
count went from 10 to 11 in some browsers.