### PR TITLE
feat: add max length constrain for goal and subgoal titles

### DIFF
--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
@@ -14,11 +14,12 @@ import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 
 // TODO: Disallow creating subgoals with empty title.
-// TODO: Enforce maximum title length for goals and subgoals.
 // TODO: Enforce maximum number of subgoals.
 // TODO: Transfer parent count to subgoal when the first one is added.
 // TODO: Disallow creating goals or subgoals with negative count.
 // TODO: Keyboard support for adding subgoals with Enter.
+const MAX_TITLE_LENGTH = 50;
+
 const EditGoalDialog = ({
   goal,
   isOpen,
@@ -91,6 +92,11 @@ const EditGoalDialog = ({
                 setEditedGoal({ ...editedGoal, title: e.target.value })
               }
               onKeyUp={e => e.key === 'Enter' && handleSave()}
+              slotProps={{
+                htmlInput: {
+                  maxLength: MAX_TITLE_LENGTH,
+                },
+              }}
             />
             <TextField
               fullWidth
@@ -139,6 +145,11 @@ const EditGoalDialog = ({
                   }
                   sx={{ flex: 1 }}
                   disabled={isLoading.save || isLoading.delete}
+                  slotProps={{
+                    htmlInput: {
+                      maxLength: MAX_TITLE_LENGTH,
+                    },
+                  }}
                 />
                 <TextField
                   size="small"

--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
@@ -103,6 +103,25 @@ describe('EditGoalDialog', () => {
     expect(screen.getByText('Delete')).toBeDisabled();
   });
 
+  it('enforces maximum length on goal and subgoal titles', async () => {
+    render(<EditGoalDialog {...propsWithSubgoals} />);
+
+    const longTitle = 'a'.repeat(60); // Longer than MAX_TITLE_LENGTH
+    const expectedTitle = longTitle.slice(0, 50); // Should be truncated
+
+    // Test parent goal title
+    const titleInput = screen.getByLabelText('Goal title');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, longTitle);
+    expect(titleInput).toHaveValue(expectedTitle);
+
+    // Test subgoal title
+    const subgoalTitleInput = screen.getAllByLabelText('Subgoal title')[0];
+    await userEvent.clear(subgoalTitleInput);
+    await userEvent.type(subgoalTitleInput, longTitle);
+    expect(subgoalTitleInput).toHaveValue(expectedTitle);
+  });
+
   describe('subgoals', () => {
     it('shows total count from subgoals in parent count field', () => {
       render(<EditGoalDialog {...propsWithSubgoals} />);

--- a/src/pages/MainPage/components/GoalInput/GoalInput.jsx
+++ b/src/pages/MainPage/components/GoalInput/GoalInput.jsx
@@ -11,6 +11,8 @@ import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 
+const MAX_TITLE_LENGTH = 50;
+
 const GoalInput = ({ onAddGoal, isLoading, suggestions = [] }) => {
   const [title, setTitle] = useState('');
   const [anchorEl, setAnchorEl] = useState(null);
@@ -101,6 +103,11 @@ const GoalInput = ({ onAddGoal, isLoading, suggestions = [] }) => {
         disabled={isLoading}
         size="small"
         sx={{ width: '100%' }}
+        slotProps={{
+          htmlInput: {
+            maxLength: MAX_TITLE_LENGTH,
+          },
+        }}
       />
       <Popper
         open={!!anchorEl && getFilteredSuggestions().length > 0}

--- a/src/pages/MainPage/components/GoalInput/GoalInput.test.jsx
+++ b/src/pages/MainPage/components/GoalInput/GoalInput.test.jsx
@@ -126,4 +126,15 @@ describe('GoalInput', () => {
       expect(screen.queryByText('Previous Goal 1')).not.toBeInTheDocument();
     });
   });
+
+  it('enforces maximum length on goal title', async () => {
+    render(<GoalInput {...defaultProps} />);
+
+    const longTitle = 'a'.repeat(60); // Longer than MAX_TITLE_LENGTH
+    const expectedTitle = longTitle.slice(0, 50); // Should be truncated
+
+    const input = screen.getByPlaceholderText('Enter new goal');
+    await userEvent.type(input, longTitle);
+    expect(input).toHaveValue(expectedTitle);
+  });
 });


### PR DESCRIPTION
The goal and subgoal titles are now limited to 50 characters.

- Modified the GoalInput and EditGoalDialog components to enforce this constraint.
- Added tests for both components.