### PR TITLE
feat: limit maximum number of subgoals to 5

### DIFF
--- a/src/constants/goals.js
+++ b/src/constants/goals.js
@@ -1,1 +1,2 @@
 export const MAX_TITLE_LENGTH = 50;
+export const MAX_SUBGOALS = 5;

--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
@@ -12,9 +12,8 @@ import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
-import { MAX_TITLE_LENGTH } from '../../../../constants/goals';
+import { MAX_TITLE_LENGTH, MAX_SUBGOALS } from '../../../../constants/goals';
 
-// TODO: Enforce maximum number of subgoals.
 // TODO: Transfer parent count to subgoal when the first one is added.
 // TODO: Disallow creating goals or subgoals with negative count.
 // TODO: Focus on the new subgoal after adding it.
@@ -33,6 +32,7 @@ const EditGoalDialog = ({
     subgoal => !subgoal.title.trim()
   );
   const subgoalRefs = useRef([]);
+  const hasMaxSubgoals = editedGoal?.subgoals?.length >= MAX_SUBGOALS;
 
   // Calculate total from subgoals if they exist
   const displayCount = hasSubgoals
@@ -44,6 +44,8 @@ const EditGoalDialog = ({
   }, [goal]);
 
   const handleAddSubgoal = () => {
+    if (hasMaxSubgoals) return null;
+
     const newSubgoal = {
       id: crypto.randomUUID(),
       title: '',
@@ -59,10 +61,12 @@ const EditGoalDialog = ({
   const handleSubgoalKeyDown = (e, index) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      handleAddSubgoal();
-      setTimeout(() => {
-        subgoalRefs.current[index + 1]?.focus();
-      }, 0);
+      if (!hasMaxSubgoals) {
+        handleAddSubgoal();
+        setTimeout(() => {
+          subgoalRefs.current[index + 1]?.focus();
+        }, 0);
+      }
     }
   };
 
@@ -135,10 +139,15 @@ const EditGoalDialog = ({
               <IconButton
                 size="small"
                 onClick={handleAddSubgoal}
-                disabled={isLoading.save || isLoading.delete}
+                disabled={isLoading.save || isLoading.delete || hasMaxSubgoals}
               >
                 <AddIcon />
               </IconButton>
+              {hasMaxSubgoals && (
+                <Typography variant="caption" color="text.secondary">
+                  Maximum {MAX_SUBGOALS} subgoals
+                </Typography>
+              )}
             </Box>
 
             {editedGoal.subgoals?.map((subgoal, index) => (

--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
@@ -319,4 +319,72 @@ describe('EditGoalDialog', () => {
       expect(finalInputs[2]).toHaveFocus();
     });
   });
+
+  describe('subgoal limit', () => {
+    it('disables add button when maximum subgoals reached', () => {
+      const propsWithMaxSubgoals = {
+        ...defaultProps,
+        goal: {
+          ...defaultProps.goal,
+          subgoals: Array(5)
+            .fill(null)
+            .map((_, index) => ({
+              id: `subgoal-${index}`,
+              title: `Subgoal ${index + 1}`,
+              count: 1,
+            })),
+        },
+      };
+
+      render(<EditGoalDialog {...propsWithMaxSubgoals} />);
+
+      const addButton = screen.getByTestId('AddIcon').closest('button');
+      expect(addButton).toBeDisabled();
+      expect(screen.getByText('Maximum 5 subgoals')).toBeInTheDocument();
+    });
+
+    it('prevents adding subgoals via keyboard when at limit', async () => {
+      const propsWithMaxSubgoals = {
+        ...defaultProps,
+        goal: {
+          ...defaultProps.goal,
+          subgoals: Array(5)
+            .fill(null)
+            .map((_, index) => ({
+              id: `subgoal-${index}`,
+              title: `Subgoal ${index + 1}`,
+              count: 1,
+            })),
+        },
+      };
+
+      render(<EditGoalDialog {...propsWithMaxSubgoals} />);
+
+      const lastInput = screen.getAllByLabelText('Subgoal title')[4];
+      await userEvent.type(lastInput, '{Enter}');
+
+      // Should still have only 5 subgoals
+      expect(screen.getAllByLabelText('Subgoal title')).toHaveLength(5);
+    });
+
+    it('shows maximum subgoals message when limit reached', () => {
+      const propsWithMaxSubgoals = {
+        ...defaultProps,
+        goal: {
+          ...defaultProps.goal,
+          subgoals: Array(5)
+            .fill(null)
+            .map((_, index) => ({
+              id: `subgoal-${index}`,
+              title: `Subgoal ${index + 1}`,
+              count: 1,
+            })),
+        },
+      };
+
+      render(<EditGoalDialog {...propsWithMaxSubgoals} />);
+
+      expect(screen.getByText('Maximum 5 subgoals')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Add a maximum limit of 5 subgoals per goal:
- Disable add button when limit is reached
- Show "Maximum 5 subgoals" message
- Prevent adding subgoals via keyboard when at limit
- Extract MAX_SUBGOALS constant for maintainability

Added tests to verify:
- Add button disables at limit
- Keyboard shortcuts respect limit
- Maximum limit message displays
- Limit enforced for both UI and keyboard interactions