### PR TITLE
feat: transfer parent goal count to first subgoal

### DIFF
--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
@@ -14,7 +14,6 @@ import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import { MAX_TITLE_LENGTH, MAX_SUBGOALS } from '../../../../constants/goals';
 
-// TODO: Transfer parent count to subgoal when the first one is added.
 // TODO: Disallow creating goals or subgoals with negative count.
 // TODO: Focus on the new subgoal after adding it.
 
@@ -49,8 +48,10 @@ const EditGoalDialog = ({
     const newSubgoal = {
       id: crypto.randomUUID(),
       title: '',
-      count: 0,
+      // Transfer parent count only when this is the first subgoal
+      count: !hasSubgoals ? editedGoal.count : 0,
     };
+
     setEditedGoal({
       ...editedGoal,
       subgoals: [...(editedGoal.subgoals || []), newSubgoal],

--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
@@ -387,4 +387,53 @@ describe('EditGoalDialog', () => {
       expect(screen.getByText('Maximum 5 subgoals')).toBeInTheDocument();
     });
   });
+
+  describe('subgoal creation', () => {
+    it('transfers parent count to first subgoal', async () => {
+      const goalWithCount = {
+        ...defaultProps.goal,
+        count: 42,
+      };
+
+      vi.spyOn(crypto, 'randomUUID').mockReturnValue('new-subgoal-id');
+      render(<EditGoalDialog {...defaultProps} goal={goalWithCount} />);
+
+      // Add first subgoal
+      await userEvent.click(screen.getByTestId('AddIcon'));
+
+      // Verify the count was transferred
+
+      // The parent input is labeled "Total count (from subgoals)" after the first subgoal is added
+      expect(screen.getByLabelText('Total count (from subgoals)')).toHaveValue(
+        42
+      );
+      // Therefore, the _first_ input labeled "Count" belongs to the first subgoal.
+      const countInputs = screen.getAllByLabelText('Count');
+      expect(countInputs[0]).toHaveValue(42);
+    });
+
+    it('does not transfer parent count to subsequent subgoals', async () => {
+      const goalWithSubgoal = {
+        ...defaultProps.goal,
+        count: 42,
+        subgoals: [
+          { id: 'existing-subgoal', title: 'First Subgoal', count: 42 },
+        ],
+      };
+
+      vi.spyOn(crypto, 'randomUUID').mockReturnValue('new-subgoal-id');
+      render(<EditGoalDialog {...defaultProps} goal={goalWithSubgoal} />);
+
+      // Add second subgoal
+      await userEvent.click(screen.getByTestId('AddIcon'));
+
+      // The parent input is labeled "Total count (from subgoals)" when we have subgoals.
+      expect(screen.getByLabelText('Total count (from subgoals)')).toHaveValue(
+        42
+      );
+      const countInputs = screen.getAllByLabelText('Count');
+      // Therefore, the _second_ input labeled "Count" belongs to the second subgoal.
+      expect(countInputs[1]).toHaveValue(0);
+    });
+  });
 });


### PR DESCRIPTION
When creating subgoals, improve count handling:
- Transfer parent goal's count to first subgoal
- Initialize subsequent subgoals with count of 0

Added tests to verify:
- Parent count transfers correctly to first subgoal
- Subsequent subgoals start with zero count
- Count transfer only happens for first subgoal