### PR TITLE
feat: prevent negative counts in goals and subgoals

### DIFF
--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
@@ -14,8 +14,8 @@ import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import { MAX_TITLE_LENGTH, MAX_SUBGOALS } from '../../../../constants/goals';
 
-// TODO: Disallow creating goals or subgoals with negative count.
 // TODO: Focus on the new subgoal after adding it.
+// TODO: Pressing Enter on an empty subgoal should save the goal without the subgoal.
 
 const EditGoalDialog = ({
   goal,
@@ -126,11 +126,16 @@ const EditGoalDialog = ({
                 !hasSubgoals &&
                 setEditedGoal({
                   ...editedGoal,
-                  count: parseInt(e.target.value) || 0,
+                  count: Math.max(0, parseInt(e.target.value) || 0),
                 })
               }
               disabled={hasSubgoals || isLoading.save || isLoading.delete}
               onKeyUp={e => e.key === 'Enter' && handleSave()}
+              slotProps={{
+                htmlInput: {
+                  min: 0,
+                },
+              }}
             />
 
             <Divider sx={{ my: 1 }} />
@@ -184,13 +189,18 @@ const EditGoalDialog = ({
                   type="number"
                   label="Count"
                   value={subgoal.count}
-                  onChange={e =>
+                  onChange={e => {
                     handleUpdateSubgoal(subgoal.id, {
-                      count: parseInt(e.target.value) || 0,
-                    })
-                  }
+                      count: Math.max(0, parseInt(e.target.value) || 0),
+                    });
+                  }}
                   sx={{ width: '100px' }}
                   disabled={isLoading.save || isLoading.delete}
+                  slotProps={{
+                    htmlInput: {
+                      min: 0,
+                    },
+                  }}
                 />
                 <IconButton
                   size="small"

--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
@@ -436,4 +436,38 @@ describe('EditGoalDialog', () => {
       expect(countInputs[1]).toHaveValue(0);
     });
   });
+
+  describe('count validation', () => {
+    it('prevents negative numbers in parent goal count', async () => {
+      render(<EditGoalDialog {...defaultProps} />);
+
+      const countInput = screen.getByLabelText('Count');
+      await userEvent.clear(countInput);
+      await userEvent.type(countInput, '-');
+      await userEvent.type(countInput, '5');
+
+      expect(countInput).toHaveValue(5);
+    });
+
+    it('prevents negative numbers in subgoal counts', async () => {
+      render(<EditGoalDialog {...propsWithSubgoals} />);
+
+      const countInputs = screen.getAllByLabelText('Count');
+      await userEvent.clear(countInputs[1]); // First subgoal count
+      await userEvent.type(countInputs[1], '-');
+      await userEvent.type(countInputs[1], '5');
+
+      expect(countInputs[1]).toHaveValue(5);
+    });
+
+    it('converts non-numeric input to 0', async () => {
+      render(<EditGoalDialog {...propsWithSubgoals} />);
+
+      const countInputs = screen.getAllByLabelText('Count');
+      await userEvent.clear(countInputs[1]);
+      await userEvent.type(countInputs[1], 'abc');
+
+      expect(countInputs[1]).toHaveValue(0);
+    });
+  });
 });


### PR DESCRIPTION
Add validation to ensure counts are always non-negative:
- Add min=0 constraint to count input fields
- Parent goal and subgoal counts cannot be negative
- Invalid or negative inputs default to 0

Updated tests to match MUI TextField number input behavior:
- Minus sign is ignored by the input
- Numeric portion of negative input is preserved
- Non-numeric input converts to zero