### PR TITLE
feat: focus new subgoal input after creation

### DIFF
--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.jsx
@@ -14,7 +14,6 @@ import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import { MAX_TITLE_LENGTH, MAX_SUBGOALS } from '../../../../constants/goals';
 
-// TODO: Focus on the new subgoal after adding it.
 // TODO: Pressing Enter on an empty subgoal should save the goal without the subgoal.
 
 const EditGoalDialog = ({
@@ -56,6 +55,13 @@ const EditGoalDialog = ({
       ...editedGoal,
       subgoals: [...(editedGoal.subgoals || []), newSubgoal],
     });
+
+    // Focus the new input after render
+    setTimeout(() => {
+      const newIndex = editedGoal.subgoals?.length || 0;
+      subgoalRefs.current[newIndex]?.focus();
+    }, 0);
+
     return newSubgoal.id;
   };
 

--- a/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
+++ b/src/pages/MainPage/components/EditGoalDialog/EditGoalDialog.test.jsx
@@ -470,4 +470,35 @@ describe('EditGoalDialog', () => {
       expect(countInputs[1]).toHaveValue(0);
     });
   });
+
+  describe('subgoal focus', () => {
+    it('focuses new subgoal input when clicking add button', async () => {
+      vi.spyOn(crypto, 'randomUUID').mockReturnValue('new-subgoal-id');
+      render(<EditGoalDialog {...defaultProps} />);
+
+      // verify the first added subgoal is focused
+      await userEvent.click(screen.getByTestId('AddIcon'));
+
+      const inputsAfterFirstAdd = screen.getAllByLabelText('Subgoal title');
+      expect(inputsAfterFirstAdd[0]).toHaveFocus();
+
+      // verify the second added subgoal is focused
+      await userEvent.click(screen.getByTestId('AddIcon'));
+
+      const inputsAfterSecondAdd = screen.getAllByLabelText('Subgoal title');
+      expect(inputsAfterSecondAdd[1]).toHaveFocus();
+    });
+
+    it('focuses new subgoal input after creating it with Enter', async () => {
+      vi.spyOn(crypto, 'randomUUID').mockReturnValue('new-subgoal-id');
+      render(<EditGoalDialog {...defaultProps} />);
+
+      await userEvent.click(screen.getByTestId('AddIcon'));
+
+      await userEvent.type(screen.getByLabelText('Subgoal title'), '{Enter}');
+
+      const inputsAfterFirstAdd = screen.getAllByLabelText('Subgoal title');
+      expect(inputsAfterFirstAdd[1]).toHaveFocus();
+    });
+  });
 });


### PR DESCRIPTION
Improve UX when adding subgoals:
- Automatically focus title input of newly created subgoal
- Focus works for both button click and keyboard creation
- Use refs for reliable input focusing

Added test to verify:
- New subgoal input receives focus after clicking add button
- Focus management works with multiple subgoals